### PR TITLE
Use an underscore for unspecified top/bottom text

### DIFF
--- a/slack/models.py
+++ b/slack/models.py
@@ -35,16 +35,10 @@ class Memegen:
         return help
 
     def build_url(self, template, top, bottom):
-        if not top and not bottom:
-            return self.BASE_URL + "/{0}.jpg".format(template)
+        path = "/{0}/{1}/{2}.jpg".format(template, top or '_', bottom or '_')
+        url = self.BASE_URL + path
 
-        if not bottom:
-            bottom = "%20"
-
-        if not top:
-            top = "%20"
-
-        return self.BASE_URL + "/{0}/{1}/{2}.jpg".format(template, top, bottom)
+        return url
 
 
 class Slack:


### PR DESCRIPTION
An underscore is considered a space: https://github.com/jacebrowning/memegen/blob/627ff423473db34bd9a91dc451cc74b2b934072b/memegen/domain/text.py#L58
