### PR TITLE
Ensure the webhook URL doesn't have extra whitespace

### DIFF
--- a/slack/models.py
+++ b/slack/models.py
@@ -60,7 +60,7 @@ class Slack:
     def __init__(self):
         self.BASE_URL = "https://slack.com/api"
         self.API_TOKEN = os.environ.get("SLACK_API_TOKEN")
-        self.WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL")
+        self.WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL").strip()
         self.SLASH_COMMAND_TOKEN = os.environ.get("SLACK_SLASH_COMMAND_TOKEN")
 
     def find_user_info(self, user_id):


### PR DESCRIPTION
If the SLACK_WEBHOOK_URL has a space or \n character at the beginning or end, the Python requests module won't be able to determine which adapter to use for it.

Fixes #4
