### PR TITLE
Fix notification text

### DIFF
--- a/slack/views.py
+++ b/slack/views.py
@@ -47,7 +47,7 @@ def meme():
     user = slack.find_user_info(user_id)
     payload.update(user)
 
-    attachments = [{"image_url": meme_url, "fallback": "Oops. Something went wrong."}]
+    attachments = [{"image_url": meme_url, "fallback": "; ".join([top, bottom])}]
     payload.update({"attachments": attachments})
 
     try:


### PR DESCRIPTION
Previously, when others are posting memes I got "Oops, something went wrong" as the notification text. This will change it to display the original semicolon-separated text instead.

Or maybe you have any better idea?

Thanks.
