### PR TITLE
Use JSON argument not data

### DIFF
--- a/slack/models.py
+++ b/slack/models.py
@@ -1,4 +1,3 @@
-import json
 import os
 from urllib import unquote_plus, quote
 import requests
@@ -72,7 +71,7 @@ class Slack:
         return {"username": username, "icon_url": icon_url}
 
     def post_meme_to_webhook(self, payload):
-        requests.post(self.WEBHOOK_URL, data=json.dumps(payload))
+        requests.post(self.WEBHOOK_URL, json=payload)
 
 
 def parse_text_into_params(text):


### PR DESCRIPTION
requests allows you to pass a dict to the json argument, instead of passing it through data as a string.

As the json library was only used for that particular line, I removed the import from the file 
