### PR TITLE
add python 'requests' module to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update
 RUN apt-get install -y python
 RUN apt-get install -y python-pip
 
+RUN pip install requests
 RUN pip install flask
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM ubuntu
 
 RUN apt-get update
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
-RUN pip install requests
-RUN pip install flask
+RUN apt-get install -y python python-pip build-essential libssl-dev libffi-dev python-dev
 
 WORKDIR /app
 
 ADD ./ /app
+
+RUN pip install -r ./requirements.txt
 
 CMD python run.py


### PR DESCRIPTION
By default, the requests module isn't installed. Needed for the container to start correctly.