### PR TITLE
accept POST method for slash command requests

### DIFF
--- a/slack/views.py
+++ b/slack/views.py
@@ -5,15 +5,11 @@ app = Flask(__name__)
 memegen = Memegen()
 slack = Slack()
 
-@app.route("/")
+@app.route("/", methods=["GET", "POST"])
 def meme():
-    if not request.args:
-        return memegen.help()
-
-    token = request.args["token"]
-    text = request.args["text"].strip()
-    channel_id = request.args["channel_id"]
-    user_id = request.args["user_id"]
+    data = request.form if request.method == 'POST' else request.args
+    token, text, channel_id, user_id = [data[key] for key in ("token", "text", "channel_id", "user_id")]
+    text = text.strip()
 
     if token != slack.SLASH_COMMAND_TOKEN:
         return "Unauthorized."


### PR DESCRIPTION
Since Slack introduced Apps (as opposed to custom integrations), slash commands have been configured to as only POST requests. You can still configure custom integrations to use GET instead, but that's not recommended.

This PR makes the route handler compatible with both GET and POST (so existing user's don't have to change their Slack config in order to update their bot).