### PR TITLE
Python 3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-cryptography==1.7.1
 Flask==0.10.1
-idna==2.2
-itsdangerous==0.24
-Jinja2==2.7.3
-MarkupSafe==0.23
-pyOpenSSL==16.2.0
 requests==2.12.4
-Werkzeug==0.10.4
-wsgiref==0.1.2

--- a/slack/models.py
+++ b/slack/models.py
@@ -1,6 +1,11 @@
 import os
-from urllib import unquote_plus, quote
+
 import requests
+
+try:
+    from urllib import unquote_plus, quote
+except ImportError:
+    from urllib.parse import unquote_plus, quote
 
 
 class Memegen:

--- a/slack/views.py
+++ b/slack/views.py
@@ -1,5 +1,5 @@
 from flask import Flask, request
-from models import Memegen, Slack, parse_text_into_params, image_exists
+from slack.models import Memegen, Slack, parse_text_into_params, image_exists
 
 app = Flask(__name__)
 memegen = Memegen()


### PR DESCRIPTION
Most of the requirements in `requirements.txt` were unnecessary. Some of them, like `Werkzeug` or `Jinja2` were already installed with [`Flask`](https://github.com/pallets/flask/blob/master/setup.py#L71). Moreover, [`wsgiref`](https://pypi.python.org/pypi/wsgiref) seemed to be unused, and broke the installation on python 3 (#32).

Also, `from urllib import unquote_plus, quote` was broken on python 3. Those functions were moved to [`urllib.parse`](https://docs.python.org/3/library/urllib.parse.html).

Finally, `from models import ...` was also broken on python 3. This statement was replaced by `from slack.models import ...` wich works as expected on both python 2 and 3.