### PR TITLE
Make the shown name the real display name

### DIFF
--- a/slack/models.py
+++ b/slack/models.py
@@ -92,7 +92,7 @@ class Slack:
         response = requests.get(url)
 
         user = response.json()["user"]
-        username = user["name"]
+        username = user["profile"]["display_name"]
         icon_url = user["profile"]["image_48"]
 
         return {"username": username, "icon_url": icon_url}


### PR DESCRIPTION
display_name != username
The displayname is shown when u post something but currently this bot uses the username when impersonating.